### PR TITLE
[openssl]: Update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-results
+results/
+inspec.lock

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.openssl?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.openssl?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=119&branchName=master)
 
 # openssl
 
@@ -37,6 +37,18 @@ To install this plan, you should run the following commands to first install, an
 will add the following binary to the PATH:
 
 * /bin/openssl
+
+For example:
+
+```bash
+$ hab pkg install core/openssl --binlink
+» Installing core/openssl
+☁ Determining latest version of core/openssl in the 'stable' channel
+→ Using core/openssl/1.0.2t/20200306005450
+★ Install of core/openssl/1.0.2t/20200306005450 complete with 0 new packages installed.
+» Binlinking openssl from core/openssl/1.0.2t/20200306005450 into /bin
+★ Binlinked openssl from core/openssl/1.0.2t/20200306005450 to /bin/openssl
+```
 
 #### Using an example binary
 

--- a/README.md
+++ b/README.md
@@ -2,97 +2,58 @@
 
 # openssl
 
-OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.
+OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.  See [documentation](https://www.openssl.org)
 
 ## Maintainers
 
-* The Habitat Maintainers: <humans@habitat.sh>
+* The Core Planners: <chef-core-planners@chef.io>
 
 ## Type of Package
 
 Binary package
 
-## Usage
+### Use as Dependency
 
-*TODO: Add instructions for usage*
+Binary packages can be set as runtime or build time dependencies. See [Defining your dependencies](https://www.habitat.sh/docs/developing-packages/developing-packages/#sts=Define%20Your%20Dependencies) for more information.
 
-## Base Plans
+To add core/openssl as a dependency, you can add one of the following to your plan file.
 
-This section outlines a general playbook for maintainers who are building this plan.
+##### Buildtime Dependency
 
-As a base plan, this plan has extra considerations when merging PRs and building the plan. This base plan can safely be built without a core plans base refresh.
+> pkg_build_deps=(core/openssl)
 
-1. The following plans must be verified as successfully building, along with success of any automated tests, before merging any PRs:
+##### Runtime dependency
 
+> pkg_deps=(core/openssl)
+
+### Use as Tool
+
+#### Installation
+
+To install this plan, you should run the following commands to first install, and then link the binaries this plan creates.
+
+``hab pkg install core/openssl --binlink``
+
+will add the following binary to the PATH:
+
+* /bin/openssl
+
+#### Using an example binary
+
+You can now use the binary as normal.  For example:
+
+``/bin/openssl --help`` or ``openssl --help``
+
+```bash
+$ openssl --help
+...
+...
+Standard commands
+asn1parse         ca                ciphers           cms               
+crl               crl2pkcs7         dgst              dh                
+dhparam           dsa               dsaparam          ec                
+ecparam           enc               engine            errstr            
+gendh             gendsa            genpkey           genrsa            
+...
+...
 ```
-core-plans/openssl
-core-plans/openssl-musl/
-habitat/components/hab/
-core-plans/libarchive
-habitat/components/sup
-core-plans/curl
-core-plans/postgresql
-builder/components/builder-api
-```
-
-It is important to verify each of these packages because Habitat is a self-hosting system. In other words, `hab` is used to build `core-plans` and `core-plans` is used to build `hab`. We need to perform this extra level of verification to ensure that a change in a base plan does not prevent the ability to ship new packages.
-
-1. Once the plan is merged, make a tracking issue on Github to document the work post merging the PR. This tracking issue should look something like: https://github.com/habitat-sh/core-plans/issues/2339
-
-1. You must verify that all upstream plans can build successfully in `unstable`. Habitat Builder will kick off any builds as soon as the PR is merged. These builds should take around 5 hours to complete. You can monitor with this:
-
-```
-hab bldr job status -o core
-```
-
-```
-☁ Determining status of job groups in core origin
-
-CREATED AT                        GROUP ID             STATUS       IDENT              TARGET
-2019-03-05T19:10:56.463614+00:00  1195769776017088512  Queued       core/openssl       x86_64-linux
-2019-03-05T19:10:47.343695+00:00  1195769699504586752  Dispatching  core/openssl       x86_64-windows
-2019-03-05T19:10:47.285353+00:00  1195769699034816512  Dispatching  core/openssl-musl  x86_64-linux
-2019-03-05T16:52:42.427858+00:00  1195700200616992768  Complete     core/cerebro       x86_64-linux
-2019-03-05T15:50:28.109165+00:00  1195668874861944832  Complete     core/hab-launcher  x86_64-linux
-2019-03-05T15:50:28.078409+00:00  1195668874627055616  Complete     core/hab-launcher  x86_64-windows
-2019-03-05T15:25:23.177315+00:00  1195656250594066432  Complete     core/nginx         x86_64-linux
-2019-03-05T15:25:22.814329+00:00  1195656247548993536  Complete     core/nginx         x86_64-windows
-2019-03-05T15:17:21.338684+00:00  1195652208618766336  Complete     core/packer        x86_64-linux
-2019-03-05T15:17:21.318397+00:00  1195652208450985984  Complete     core/packer        x86_64-windows
-```
-
-```
-watch -n300 "hab bldr job status 1195769776017088512 -s | grep core/ | grep Failure"
-```
-
-1. Make a list of any failed builds and investigate any failures. At this point you will want to document issues with failures, or if the failures are transient, note them as such in the tracking issue.
-
-1. At this point you can make a determination if any of the issues above are blocking promotion. You will want to block promotion if failed builds caused other core plans to become `Skipped`, but may also want to block based on other issues.
-
-1. If you are not blocked from promoting, now you will want to promote the base plan package (in this case `openssl`).
-
-1. Now you will want to interactively promote upstream packages. You can do this with:
-
-```
-hab bldr job promote <group_number> stable -o core -i
-```
-
-Where <number> is the job number.
-
-Remove any packages with `hab` in the name. DO NOT PROMOTE ANYTHING WITH `hab` in the name!
-
-1. Now you will need to do this for each job group. Note that there is currently a Builder API bug where Windows packages will return an error:
-
-```
-XXX
-XXX Failed to promote job group: APIError(NotFound, "")
-XXX
-```
-
-These will have to be promoted in the UI separately.
-
-1. Finally, you will want to track and rebuild any packages that Failed during the build after you merged the PR. Rebuild any packages, regardless if they have known build issues or were transient failures.
-
-1. Add any documentation that you learned during the process.
-
-1. Close the tracking issue.

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,1 +1,2 @@
-command_relative_path: '/bin/openssl'
+plan_name: 'openssl'
+command_relative_path: 'bin/openssl'

--- a/controls/openssl_exists.rb
+++ b/controls/openssl_exists.rb
@@ -7,16 +7,17 @@ control 'core-plans-openssl-exists' do
   impact 1.0
   title 'Ensure openssl exists'
   desc '
-  Verify openssl by ensuring /bin/openssl exists'
+  Verify openssl by ensuring bin/openssl exists'
   
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
   end
 
-  command_relative_path = input('command_relative_path', value: '/bin/openssl')
-  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+  command_relative_path = input('command_relative_path', value: 'bin/openssl')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, command_relative_path)
   describe file(command_full_path) do
     it { should exist }
   end

--- a/controls/openssl_works.rb
+++ b/controls/openssl_works.rb
@@ -7,26 +7,30 @@ control 'core-plans-openssl-works' do
   impact 1.0
   title 'Ensure openssl works as expected'
   desc '
-  Verify openssl by ensuring (1) its installation directory exists and (2) that
-  it returns the expected version; (3) it successfully base64 encodes text
+  Verify openssl by ensuring that
+  (1) its installation directory exists 
+  (2) it returns the expected version
+  (3) it successfully base64 encodes text
   '
   
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
   end
   
-  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
-  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
-  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} openssl version") do
+  command_relative_path = input('command_relative_path', value: 'bin/openssl')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, command_relative_path)
+  plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
+  describe command("#{command_full_path} version") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
     its('stdout') { should match /OpenSSL #{plan_pkg_version}/ }
     its('stderr') { should be_empty }
   end
 
-  describe command("echo 'a_byte_character' | hab pkg exec #{plan_pkg_ident} openssl enc -base64") do
+  describe command("echo 'a_byte_character' | #{command_full_path} enc -base64") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
     its('stdout') { should match /YV9ieXRlX2NoYXJhY3Rlcgo=/ }

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,7 @@
 name: openssl
 title: Habitat Core Plan openssl
-maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+maintainer: "The Core Planners <chef-core-planners@chef.io>"
 summary: InSpec controls for testing Habitat Core Plan openssl
-copyright: 2019, Chef Software, Inc.
-copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
-inspec_version: '>= 3.0.25'
+inspec_version: '>= 4.18.108'


### PR DESCRIPTION
FYI: I have replaced original plan README text that identifies this as a baseplan and instructs on how to rebuild habitat, etc.  The refresh build and upstream users of this plan should manage their own logic around changes to this plan.