### PR TITLE
Add OpenSSL 1.0.2x

### DIFF
--- a/plan.sh
+++ b/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=openssl
 _distname="$pkg_name"
 pkg_origin=core
-pkg_version=1.0.2w
+pkg_version=1.0.2x
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
 OpenSSL is an open source project that provides a robust, commercial-grade, \
@@ -12,7 +12,7 @@ library.\
 pkg_upstream_url="https://www.openssl.org"
 pkg_license=('OpenSSL')
 pkg_source="https://s3.amazonaws.com/chef-releng/${_distname}/${_distname}-${pkg_version}.tar.gz"
-pkg_shasum=a675ad1a9df59015cebcdf713de76a422347c5d99f11232fe75758143defd680
+pkg_shasum=79cb4e20004a0d1301210aee7e154ddfba3d6a33d0df1f6c5d3257cb915a59c9
 pkg_dirname="${_distname}-${pkg_version}"
 pkg_deps=(
   core/glibc


### PR DESCRIPTION
Fixes CVE-2020-1971

https://www.openssl.org/news/secadv/20201208.txt

Signed-off-by: Bryan McLellan <btm@loftninjas.org>