### PR TITLE
Bump to the latest 1.0.2 premium release

### DIFF
--- a/plan.sh
+++ b/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=openssl
 _distname="$pkg_name"
 pkg_origin=core
-pkg_version=1.0.2w
+pkg_version=1.0.2y
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
 OpenSSL is an open source project that provides a robust, commercial-grade, \
@@ -12,7 +12,7 @@ library.\
 pkg_upstream_url="https://www.openssl.org"
 pkg_license=('OpenSSL')
 pkg_source="https://s3.amazonaws.com/chef-releng/${_distname}/${_distname}-${pkg_version}.tar.gz"
-pkg_shasum=a675ad1a9df59015cebcdf713de76a422347c5d99f11232fe75758143defd680
+pkg_shasum=4882ec99f8e147ab26375da8a6af92efae69b6aef505234764f8cd00a1b81ffc
 pkg_dirname="${_distname}-${pkg_version}"
 pkg_deps=(
   core/glibc


### PR DESCRIPTION
OpenSSL 1.0.2 is EOL but we maintain a long term support contract.