### PR TITLE
fix: openssl to use cacerts package instead of default

### DIFF
--- a/ca_dir.patch
+++ b/ca_dir.patch
@@ -1,0 +1,50 @@
+diff --git a/apps/CA.pl.in b/apps/CA.pl.in
+index 3bf4c99f31..0856fbcfac 100644
+--- a/apps/CA.pl.in
++++ b/apps/CA.pl.in
+@@ -53,7 +53,7 @@ $VERIFY="$openssl verify";
+ $X509="$openssl x509";
+ $PKCS12="$openssl pkcs12";
+ 
+-$CATOP="./demoCA";
++$CATOP="@cacerts_prefix@/ssl/certs";
+ $CAKEY="cakey.pem";
+ $CAREQ="careq.pem";
+ $CACERT="cacert.pem";
+diff --git a/apps/openssl.cnf b/apps/openssl.cnf
+index 1eb86c4012..3602149fc7 100644
+--- a/apps/openssl.cnf
++++ b/apps/openssl.cnf
+@@ -39,7 +39,7 @@ default_ca	= CA_default		# The default ca section
+ ####################################################################
+ [ CA_default ]
+ 
+-dir		= ./demoCA		# Where everything is kept
++dir		= @cacerts_prefix@/ssl		# Where everything is kept
+ certs		= $dir/certs		# Where the issued certs are kept
+ crl_dir		= $dir/crl		# Where the issued crl are kept
+ database	= $dir/index.txt	# database index file.
+@@ -47,7 +47,7 @@ database	= $dir/index.txt	# database index file.
+ 					# several ctificates with same subject.
+ new_certs_dir	= $dir/newcerts		# default place for new certs.
+ 
+-certificate	= $dir/cacert.pem 	# The CA certificate
++certificate	= $certs/cacert.pem 	# The CA certificate
+ serial		= $dir/serial 		# The current serial number
+ crlnumber	= $dir/crlnumber	# the current crl number
+ 					# must be commented out to leave a V1 CRL
+diff --git a/crypto/cryptlib.h b/crypto/cryptlib.h
+index 2f9eced4ae..a7376debe9 100644
+--- a/crypto/cryptlib.h
++++ b/crypto/cryptlib.h
+@@ -81,8 +81,8 @@ extern "C" {
+ 
+ # ifndef OPENSSL_SYS_VMS
+ #  define X509_CERT_AREA          OPENSSLDIR
+-#  define X509_CERT_DIR           OPENSSLDIR "/certs"
+-#  define X509_CERT_FILE          OPENSSLDIR "/cert.pem"
++#  define X509_CERT_DIR           "@cacerts_prefix@/ssl"
++#  define X509_CERT_FILE          "@cacerts_prefix@/ssl/cert.pem"
+ #  define X509_PRIVATE_DIR        OPENSSLDIR "/private"
+ # else
+ #  define X509_CERT_AREA          "SSLROOT:[000000]"

--- a/plan.sh
+++ b/plan.sh
@@ -37,6 +37,14 @@ pkg_pconfig_dirs=(lib/pkgconfig)
 _common_prepare() {
   do_default_prepare
 
+  # Set CA dir to `$pkg_prefix/ssl` by default and use the cacerts from the
+  # `cacerts` package. Note that `patch(1)` is making backups because
+  # we need an original for the test suite.
+  # DO NOT REMOVE
+  sed -e "s,@cacerts_prefix@,$(pkg_path_for cacerts),g" \
+      "$PLAN_CONTEXT/ca_dir.patch" \
+      | patch -p1 --backup
+
   if [[ ! -f "/bin/rm" ]]; then
     hab pkg binlink core/coreutils rm --dest /bin
     BINLINKED_RM=true


### PR DESCRIPTION
Fix for issue https://github.com/habitat-sh/core-plans/issues/4051
Signed-off-by: Nimit <nimit.jyotiana@hotmail.com>